### PR TITLE
Hide header during round end animation

### DIFF
--- a/client/Board.tsx
+++ b/client/Board.tsx
@@ -35,6 +35,7 @@ import ReactionBubbles from "./ReactionBubbles";
 import {
   RoundEndSequenceOverlay,
   RoundEndSequenceProvider,
+  useRoundEndSequence,
   type RoundEndAnimationMode,
 } from "./RoundEndSequence";
 import {
@@ -75,6 +76,7 @@ type Props = {
   isDeckCyclingBlocked?: boolean;
   isInteractionDisabled?: boolean;
   onBlockedMove?: () => void;
+  onRoundEndAnimationChange?: (isAnimating: boolean) => void;
   roomId?: string | null;
   roundEndAnimationMode?: RoundEndAnimationMode;
   visiblePlayerIndices?: readonly number[];
@@ -174,6 +176,7 @@ export default observer(function Board({
   isDeckCyclingBlocked = false,
   isInteractionDisabled = false,
   onBlockedMove,
+  onRoundEndAnimationChange,
   onUpdateHand,
   roomId,
   roundEndAnimationMode = "auto",
@@ -344,6 +347,9 @@ export default observer(function Board({
               board={board}
               mode={roundEndAnimationMode}
             >
+              <RoundEndAnimationReporter
+                onChange={onRoundEndAnimationChange}
+              />
               <PileSection roomId={roomId} />
               <ScoresTableTabOverlay
                 aiMode={state.roomSettings.aiMode}
@@ -400,6 +406,24 @@ export default observer(function Board({
     </DndProvider>
   );
 });
+
+function RoundEndAnimationReporter({
+  onChange,
+}: {
+  onChange?: (isAnimating: boolean) => void;
+}) {
+  const { isAnimating = false } = useRoundEndSequence();
+
+  useIsomorphicLayoutEffect(() => {
+    onChange?.(isAnimating);
+  }, [isAnimating, onChange]);
+
+  useIsomorphicLayoutEffect(() => {
+    return () => onChange?.(false);
+  }, [onChange]);
+
+  return null;
+}
 
 function getDndBackendOptions(inputMode: ResolvedDragInputMode) {
   if (inputMode === "mouse") {

--- a/client/Header.tsx
+++ b/client/Header.tsx
@@ -27,6 +27,7 @@ import type { AIMode } from "../shared/RoomState";
 const PENDING_MOVE_SYNC_BADGE_DELAY_MS = 2000;
 
 type Props = {
+  isRoundEndAnimationActive?: boolean;
   roomId?: string | null;
   onLeaveRoom: () => void;
 };
@@ -63,70 +64,75 @@ export default observer(function Header(props: Props) {
     !isHost &&
     props.roomId != null &&
     props.roomId.toLowerCase() !== "offline";
+  const showHeaderControls = props.isRoundEndAnimationActive !== true;
   return (
     <>
-      {showRoomCode ? (
+      {showHeaderControls && showRoomCode ? (
         <div className={styles.roomCodeBadge}>
           <span>Room</span>
           <strong>{props.roomId}</strong>
         </div>
       ) : null}
-      <div
-        className={styles.floatingControls}
-        role="toolbar"
-        aria-label="Game controls"
-      >
-        <PendingMoveSyncBadgeContainer />
-        {settings.showNetworkStats ? (
-          <NetworkStatsIndicator roomId={props.roomId} />
-        ) : null}
-        {settings.showFramerate ? <FramerateIndicator /> : null}
-        {canSendReactions ? (
-          <HeaderReactionButton
-            onSelectReaction={(reactionId) =>
-              socket?.emit("send_reaction", { reactionId })
-            }
-          />
-        ) : null}
-        {canTogglePause ? (
-          <HeaderPauseButton
-            isPaused={isPaused}
-            onToggle={() => socket?.emit("set_paused", { paused: !isPaused })}
-          />
-        ) : null}
-        {board != null && board.pouncer == null ? (
-          <HeaderScoreboardButton
-            aiMode={state.roomSettings.aiMode}
-            board={board}
-          />
-        ) : null}
-        {showStuckButton ? (
-          <HeaderStuckButton
-            disabled={!canMarkStuck}
-            isStuck={isActivePlayerStuck}
-            stuckCount={stuckStatus.count}
-            stuckTotal={stuckStatus.total}
-            onToggle={() =>
-              socket?.emit("set_stuck", { stuck: !isActivePlayerStuck })
-            }
-          />
-        ) : null}
-        <DesktopOnlyTooltip title="Open settings">
-          <button
-            className={`${styles.floatingButton} ${styles.settingsButton}`}
-            onClick={() => settings.openSettings("main")}
-            aria-label="Open settings"
-            type="button"
-          >
-            <SettingOutlined
-              aria-hidden="true"
-              className={styles.settingsIcon}
-              rev={undefined}
+      {showHeaderControls ? (
+        <div
+          className={styles.floatingControls}
+          role="toolbar"
+          aria-label="Game controls"
+        >
+          <PendingMoveSyncBadgeContainer />
+          {settings.showNetworkStats ? (
+            <NetworkStatsIndicator roomId={props.roomId} />
+          ) : null}
+          {settings.showFramerate ? <FramerateIndicator /> : null}
+          {canSendReactions ? (
+            <HeaderReactionButton
+              onSelectReaction={(reactionId) =>
+                socket?.emit("send_reaction", { reactionId })
+              }
             />
-            <span className={styles.buttonLabel}>Settings</span>
-          </button>
-        </DesktopOnlyTooltip>
-      </div>
+          ) : null}
+          {canTogglePause ? (
+            <HeaderPauseButton
+              isPaused={isPaused}
+              onToggle={() =>
+                socket?.emit("set_paused", { paused: !isPaused })
+              }
+            />
+          ) : null}
+          {board != null && board.pouncer == null ? (
+            <HeaderScoreboardButton
+              aiMode={state.roomSettings.aiMode}
+              board={board}
+            />
+          ) : null}
+          {showStuckButton ? (
+            <HeaderStuckButton
+              disabled={!canMarkStuck}
+              isStuck={isActivePlayerStuck}
+              stuckCount={stuckStatus.count}
+              stuckTotal={stuckStatus.total}
+              onToggle={() =>
+                socket?.emit("set_stuck", { stuck: !isActivePlayerStuck })
+              }
+            />
+          ) : null}
+          <DesktopOnlyTooltip title="Open settings">
+            <button
+              className={`${styles.floatingButton} ${styles.settingsButton}`}
+              onClick={() => settings.openSettings("main")}
+              aria-label="Open settings"
+              type="button"
+            >
+              <SettingOutlined
+                aria-hidden="true"
+                className={styles.settingsIcon}
+                rev={undefined}
+              />
+              <span className={styles.buttonLabel}>Settings</span>
+            </button>
+          </DesktopOnlyTooltip>
+        </div>
+      ) : null}
       {settings.isSettingsOpen ? (
         <SettingsDialog
           onLeaveRoom={props.onLeaveRoom}

--- a/pages/offline.tsx
+++ b/pages/offline.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "antd";
 import Board from "../client/Board";
@@ -23,6 +23,8 @@ const OfflinePage: NextPage<{
   const settings = useClientSettingsStore();
   const playerName = name || "Player";
   const { actions, isConnected, state, socket } = useLocalGame(playerName);
+  const [isRoundEndAnimationActive, setRoundEndAnimationActive] =
+    useState(false);
 
   useEffect(() => {
     if (!name) {
@@ -92,11 +94,16 @@ const OfflinePage: NextPage<{
         )}
       >
         <ClientProvider settings={settings} state={state} socket={socket}>
-          <Header onLeaveRoom={onLeaveRoom} roomId="Offline" />
+          <Header
+            isRoundEndAnimationActive={isRoundEndAnimationActive}
+            onLeaveRoom={onLeaveRoom}
+            roomId="Offline"
+          />
           <div className={styles.boardWrapper}>
             <Board
               onUpdateHand={actions.onUpdateHand}
               executeMove={actions.executeMove}
+              onRoundEndAnimationChange={setRoundEndAnimationActive}
               roomId="Offline"
             />
           </div>

--- a/pages/r/[roomid].tsx
+++ b/pages/r/[roomid].tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import Board from "../../client/Board";
 import Head from "next/head";
@@ -27,6 +27,8 @@ const RoomPage = observer(
       roomId,
       name
     );
+    const [isRoundEndAnimationActive, setRoundEndAnimationActive] =
+      useState(false);
     const onLeaveRoom = useCallback(() => {
       router.push("/");
     }, []);
@@ -100,11 +102,16 @@ const RoomPage = observer(
             state={state}
             socket={isConnected ? socket : null}
           >
-            <Header onLeaveRoom={onLeaveRoom} roomId={roomId} />
+            <Header
+              isRoundEndAnimationActive={isRoundEndAnimationActive}
+              onLeaveRoom={onLeaveRoom}
+              roomId={roomId}
+            />
             <div className={styles.boardWrapper}>
               <Board
                 onUpdateHand={actions.onUpdateHand}
                 executeMove={actions.executeMove}
+                onRoundEndAnimationChange={setRoundEndAnimationActive}
                 roomId={roomId}
               />
             </div>


### PR DESCRIPTION
## Summary
- report the round-end animation state from `Board`
- hide the header controls and room-code badge on game routes while that animation is active

## Testing
- `node node_modules\typescript\bin\tsc --noEmit --incremental false`