### PR TITLE
Delay AI opening moves

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "start-socketio": "PORT=3001 ts-node --transpile-only server/socketioMain.ts",
     "test:fair-hands": "node ./node_modules/ts-node/dist/bin.js --transpile-only shared/FairHands.test.ts",
     "test:action-ranking-policy": "ts-node --transpile-only shared/ActionRankingPolicy.test.ts",
+    "test:room-logic": "node ./node_modules/ts-node/dist/bin.js --transpile-only shared/RoomLogic.test.ts",
     "test:room-delta": "node ./node_modules/ts-node/dist/bin.js --transpile-only shared/RoomDelta.test.ts",
     "test:socket-state": "node ./node_modules/ts-node/dist/bin.js --transpile-only client/SocketState.test.ts",
     "test:pounce-rush": "ts-node --transpile-only shared/PounceRush.test.ts",

--- a/shared/RoomLogic.test.ts
+++ b/shared/RoomLogic.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+
+import {
+  completeRoundStartCountdown,
+  dealRoomHands,
+  getReactionDelay,
+  startRoomGame,
+} from "./RoomLogic";
+import { createRoomState } from "./RoomState";
+
+{
+  const room = createRoomState(2);
+  const now = 1000;
+  const countdownMs = 3000;
+  const randomJitter = 0.5;
+
+  assert.equal(dealRoomHands(room), true);
+
+  withStubbedRandom(randomJitter, () => {
+    startRoomGame(room, now, { countdownMs });
+    const startsAt = now + countdownMs;
+    const expectedOpeningCooldown =
+      startsAt + getReactionDelay(room) / 4 + randomJitter;
+
+    assert.equal(room.board.roundStartsAt, startsAt);
+    assert.deepEqual(
+      room.aiCooldowns,
+      room.board.players.map(() => expectedOpeningCooldown)
+    );
+    assert.equal(completeRoundStartCountdown(room, startsAt - 1), false);
+
+    assert.equal(completeRoundStartCountdown(room, startsAt), true);
+    assert.equal(room.board.roundStartsAt, undefined);
+    assert.deepEqual(
+      room.aiCooldowns,
+      room.board.players.map(() => expectedOpeningCooldown)
+    );
+  });
+}
+
+function withStubbedRandom(value: number, fn: () => void): void {
+  const originalRandom = Math.random;
+  Math.random = () => value;
+  try {
+    fn();
+  } finally {
+    Math.random = originalRandom;
+  }
+}

--- a/shared/RoomLogic.ts
+++ b/shared/RoomLogic.ts
@@ -86,6 +86,7 @@ const AI_PILE_KNOWLEDGE_REACTION_MULTIPLIER = 2;
 const AI_OBSOLETE_TARGET_RECONSIDER_DELAY_RATIO = 0.45;
 const AI_OBSOLETE_TARGET_RECONSIDER_MIN_DELAY_MS = 120;
 const AI_OBSOLETE_TARGET_RECONSIDER_MAX_DELAY_MS = 650;
+const AI_OPENING_MOVE_REACTION_DELAY_RATIO = 0.25;
 const MIN_ROUND_READY_PLAYERS = 2;
 const FAIREST_DEAL_SIMULATION_TRIALS = 12;
 const FAIREST_DEAL_MAX_MOVES_PER_TRIAL = 1400;
@@ -831,12 +832,16 @@ export function startRoomGame(
 
   const startsAt = now + countdownMs;
   room.board.roundStartsAt = startsAt;
-  room.aiCooldowns = room.board.players.map(() => startsAt + Math.random());
+  room.aiCooldowns = room.board.players.map(() =>
+    getAIOpeningMoveCooldown(room, startsAt)
+  );
 }
 
 function beginRoomGame(room: RoomState, now: number): void {
   room.board.roundStartsAt = undefined;
-  room.aiCooldowns = room.board.players.map(() => now + Math.random());
+  room.aiCooldowns = room.board.players.map(() =>
+    getAIOpeningMoveCooldown(room, now)
+  );
   room.handUpdateVersions = [];
   startRoundAnalysis(room, now);
   room.aiBoard = deepClone(room.board);
@@ -862,6 +867,14 @@ export function completeRoundStartCountdown(
 
 function getRoomStartCountdownDurationMs(room: RoomState): number {
   return room.autoStart ? 0 : ROUND_START_COUNTDOWN_MS / room.timescale;
+}
+
+function getAIOpeningMoveCooldown(room: RoomState, now: number): number {
+  return (
+    now +
+    getReactionDelay(room) * AI_OPENING_MOVE_REACTION_DELAY_RATIO +
+    Math.random()
+  );
 }
 
 export function dealRoomHands(room: RoomState): boolean {


### PR DESCRIPTION
Summary: Delay round-opening AI cooldowns by one quarter of the current reaction delay and add focused RoomLogic coverage. Tests: npm.cmd run test:room-logic. node node_modules\typescript\bin\tsc --noEmit --incremental false.