### PR TITLE
Delay AI retarget after stale center drags

### DIFF
--- a/shared/RoomDelta.test.ts
+++ b/shared/RoomDelta.test.ts
@@ -14,6 +14,21 @@ const aceOfHearts: CardState = {
   suit: "hearts",
   value: 1,
 };
+const twoOfHearts: CardState = {
+  player: 0,
+  suit: "hearts",
+  value: 2,
+};
+const otherAceOfHearts: CardState = {
+  player: 1,
+  suit: "hearts",
+  value: 1,
+};
+const otherTwoOfHearts: CardState = {
+  player: 1,
+  suit: "hearts",
+  value: 2,
+};
 
 {
   const board = createOnePlayerBoardWithPounceCard(aceOfHearts);
@@ -63,6 +78,58 @@ const aceOfHearts: CardState = {
   assert.deepEqual(room.board.piles[0], []);
   assert.equal(room.board.ticksSinceMove, 0);
   assert.equal(room.board.ticksSinceNonWaitMove, 0);
+}
+
+{
+  const room = createRoomState(1);
+  room.board = createOnePlayerBoardWithPounceCard(twoOfHearts);
+  room.board.piles[0] = [aceOfHearts, otherTwoOfHearts];
+  room.board.piles[1] = [otherAceOfHearts];
+  room.aiBoard = deepClone(room.board);
+  room.hands = [
+    {
+      location: aceOfHearts,
+      item: twoOfHearts,
+      items: [twoOfHearts],
+    },
+  ];
+  room.handUpdateVersions = [];
+  room.aiCooldowns = [0];
+  room.aiSpeed = 1;
+  room.timescale = 1;
+  room.settings.aiMode = "fixed";
+  room.settings.simulationMode = false;
+
+  const result = tickRoom(room, 1000);
+  const delta = getRoomHandDelta(room, 0);
+
+  assert.equal(result.hasUpdate, false);
+  assert.equal(result.actions.length, 0);
+  assert.equal(result.hasHandUpdate, false);
+  assert.deepEqual(result.handUpdatePlayerIndices, []);
+  assert.deepEqual(delta?.hand.location, aceOfHearts);
+  assert.deepEqual(delta?.hand.item, twoOfHearts);
+  assert.deepEqual(delta?.hand.items, [twoOfHearts]);
+  assert.equal(delta?.version, 0);
+  assert.deepEqual(room.board.players[0].pounceDeck, [twoOfHearts]);
+  assert.deepEqual(room.board.piles[0], [aceOfHearts, otherTwoOfHearts]);
+  assert.deepEqual(room.board.piles[1], [otherAceOfHearts]);
+  assert.equal(room.aiCooldowns[0], 1650);
+
+  const retargetResult = tickRoom(room, 1650);
+  const retargetDelta = getRoomHandDelta(room, 0);
+
+  assert.equal(retargetResult.hasUpdate, false);
+  assert.equal(retargetResult.actions.length, 0);
+  assert.equal(retargetResult.hasHandUpdate, true);
+  assert.deepEqual(retargetResult.handUpdatePlayerIndices, [0]);
+  assert.deepEqual(retargetDelta?.hand.location, otherAceOfHearts);
+  assert.deepEqual(retargetDelta?.hand.item, twoOfHearts);
+  assert.deepEqual(retargetDelta?.hand.items, [twoOfHearts]);
+  assert.equal(retargetDelta?.version, 1);
+  assert.deepEqual(room.board.players[0].pounceDeck, [twoOfHearts]);
+  assert.deepEqual(room.board.piles[0], [aceOfHearts, otherTwoOfHearts]);
+  assert.deepEqual(room.board.piles[1], [otherAceOfHearts]);
 }
 
 function createOnePlayerBoardWithPounceCard(card: CardState): BoardState {

--- a/shared/RoomLogic.ts
+++ b/shared/RoomLogic.ts
@@ -27,6 +27,7 @@ import {
 } from "./AIDifficulty";
 import {
   normalizeAIMode,
+  type AICenterRetargetPause,
   type AIPileKnowledge,
   type RoomState,
 } from "./RoomState";
@@ -146,6 +147,10 @@ export function tickRoom(room: RoomState, now = Date.now()): RoomTickResult {
       const hand = (room.hands[index] = room.hands[index] ?? {});
       if (usesDelayedAIVisibility) {
         rememberAIActiveCenterPile(room, index, now);
+        if (pauseObsoleteAICenterDrag(room, index)) {
+          aiCooldowns[index] = now + getAIRetargetDelay(room);
+          continue;
+        }
       }
       const currentDragMove = getCurrentAIDragMove(board, index, hand);
       const visibleBoard = getVisibleBoard(room, index, now);
@@ -597,6 +602,88 @@ function rememberAIActiveCenterPile(
   rememberAICenterPileTop(room, playerIndex, pileIndex, now);
 }
 
+function pauseObsoleteAICenterDrag(
+  room: RoomState,
+  playerIndex: number
+): boolean {
+  const pause = getObsoleteAICenterDragPause(room, playerIndex);
+  if (!pause) {
+    clearAICenterRetargetPause(room, playerIndex);
+    return false;
+  }
+
+  const pauses = getAICenterRetargetPauses(room);
+  if (aiCenterRetargetPausesEqual(pauses[playerIndex], pause)) {
+    return false;
+  }
+
+  pauses[playerIndex] = pause;
+  return true;
+}
+
+function getObsoleteAICenterDragPause(
+  room: RoomState,
+  playerIndex: number
+): AICenterRetargetPause | null {
+  const hand = room.hands[playerIndex];
+  if (!hand?.item || !hand.location || !isCardCursorLocation(hand.location)) {
+    return null;
+  }
+
+  const pileIndex = getCenterPileIndexContainingCard(room.board, hand.location);
+  if (pileIndex < 0) {
+    return null;
+  }
+
+  const targetTopCard = peek(room.board.piles[pileIndex]);
+  if (
+    !targetTopCard ||
+    targetTopCard.suit !== hand.item.suit ||
+    targetTopCard.value < hand.item.value
+  ) {
+    return null;
+  }
+
+  return {
+    heldCard: { ...hand.item },
+    targetCard: { ...hand.location },
+    blockingCard: { ...targetTopCard },
+  };
+}
+
+function clearAICenterRetargetPause(
+  room: RoomState,
+  playerIndex: number
+): void {
+  const pauses = getAICenterRetargetPauses(room);
+  pauses[playerIndex] = null;
+}
+
+function getAICenterRetargetPauses(
+  room: RoomState
+): (AICenterRetargetPause | null)[] {
+  const pauses =
+    room.aiCenterRetargetPauses ?? (room.aiCenterRetargetPauses = []);
+  pauses.length = room.board.players.length;
+  for (let index = 0; index < pauses.length; index++) {
+    pauses[index] = pauses[index] ?? null;
+  }
+  return pauses;
+}
+
+function aiCenterRetargetPausesEqual(
+  first: AICenterRetargetPause | null | undefined,
+  second: AICenterRetargetPause | null | undefined
+): boolean {
+  return (
+    first != null &&
+    second != null &&
+    cardEquals(first.heldCard, second.heldCard) &&
+    cardEquals(first.targetCard, second.targetCard) &&
+    cardEquals(first.blockingCard, second.blockingCard)
+  );
+}
+
 function pauseObsoleteAICenterMove(
   room: RoomState,
   playerIndex: number,
@@ -783,6 +870,7 @@ function resetAIVisibilityMemory(room: RoomState): void {
   room.aiPileKnowledge = room.board.players.map(() =>
     Array(room.board.piles.length).fill(null)
   );
+  room.aiCenterRetargetPauses = room.board.players.map(() => null);
 }
 
 export function scheduleAIReactionBoard(room: RoomState): void {

--- a/shared/RoomState.ts
+++ b/shared/RoomState.ts
@@ -16,6 +16,12 @@ export type AIPileKnowledge = {
   expiresAt: number;
 };
 
+export type AICenterRetargetPause = {
+  heldCard: CardState;
+  targetCard: CardState;
+  blockingCard: CardState;
+};
+
 export type AIMode = "fixed" | "trained" | "hybrid";
 export type ResolvedAIPlayerMode = "fixed" | "trained";
 
@@ -47,6 +53,11 @@ export type RoomState = {
    * This blocks stale delayed-board retries without making the pile fully live.
    */
   aiPileKnowledge: (AIPileKnowledge | null)[][];
+  /**
+   * Last stale center drag each AI has already paused for, so a held card can
+   * hesitate once and then retarget without mutating the visible cursor state.
+   */
+  aiCenterRetargetPauses: (AICenterRetargetPause | null)[];
   queuedHands: CardState[][][];
   stuckPlayerIndices: number[];
   autoStart: boolean;
@@ -68,6 +79,7 @@ export function createRoomState(playerCount: number): RoomState {
     aiPileKnowledge: board.players.map(() =>
       Array(board.piles.length).fill(null)
     ),
+    aiCenterRetargetPauses: board.players.map(() => null),
     queuedHands: [],
     stuckPlayerIndices: [],
     autoStart: false,


### PR DESCRIPTION
## Summary
- restore a short AI retarget pause when a held center card is sitting on a stale/advanced center pile
- keep the visible AI cursor state intact by tracking a one-shot stale-target pause marker instead of clearing the held card
- add a room-delta regression test that waits once, then retargets on the next eligible tick

## Verification
- npm.cmd run test:room-delta
- npx.cmd tsc --noEmit --incremental false