### PR TITLE
Prefer central piles for AI Aces

### DIFF
--- a/shared/ActionRankingPolicy.test.ts
+++ b/shared/ActionRankingPolicy.test.ts
@@ -5,8 +5,14 @@ import {
   enumerateLegalMoves,
   getMoveImmediatePointDelta,
 } from "./ActionRankingPolicy";
+import { getBasicAIMove } from "./ComputerV1";
 import { createBoard, type BoardState, type CardState } from "./GameUtils";
-import { executeMove, type Move } from "./MoveHandler";
+import {
+  executeMove,
+  resolveAIMoveForBoard,
+  resolveMoveForBoard,
+  type Move,
+} from "./MoveHandler";
 
 const expectedMovesByType = {
   c2c: [
@@ -111,6 +117,47 @@ assert.notStrictEqual(deckCycleFeatureIndex, -1);
   assert.strictEqual(player.playedDeckCardThisCycle, false);
 }
 
+{
+  const board = createActiveBoard();
+  const player = board.players[0];
+  board.pileLocs = createCenterPreferencePileLocs();
+  player.pounceDeck = [card("hearts", 1)];
+
+  const basicMove = getBasicAIMove(board, 0, {});
+  assert.strictEqual(
+    basicMove?.type === "c2c" ? basicMove.dest : -1,
+    2,
+    "basic AI should choose the most central empty pile for Aces"
+  );
+
+  const offCenterAceMove: Move = {
+    type: "c2c",
+    source: { type: "pounce" },
+    dest: 0,
+  };
+  const genericResolvedMove = resolveMoveForBoard(board, 0, offCenterAceMove);
+  assert.strictEqual(
+    genericResolvedMove.type === "c2c" ? genericResolvedMove.dest : -1,
+    0,
+    "generic move resolution should not override an available Ace pile choice"
+  );
+
+  const resolvedAIMove = resolveAIMoveForBoard(board, 0, offCenterAceMove);
+  assert.strictEqual(
+    resolvedAIMove.type === "c2c" ? resolvedAIMove.dest : -1,
+    2,
+    "AI move resolution should retarget Aces to the most central empty pile"
+  );
+
+  board.piles[0] = [card("spades", 1, 1)];
+  const resolvedStaleAIMove = resolveAIMoveForBoard(board, 0, offCenterAceMove);
+  assert.strictEqual(
+    resolvedStaleAIMove.type === "c2c" ? resolvedStaleAIMove.dest : -1,
+    2,
+    "stale AI Ace moves should retarget to the most central empty pile"
+  );
+}
+
 console.log("Validated action-ranking policy helpers.");
 
 function createActiveBoard(): BoardState {
@@ -135,4 +182,17 @@ function card(
   player = 0
 ): CardState {
   return { suit, value, player };
+}
+
+function createCenterPreferencePileLocs(): BoardState["pileLocs"] {
+  return [
+    [0.05, 0.05, 0],
+    [0.95, 0.95, 0],
+    [0.5, 0.48, 0],
+    [0.12, 0.8, 0],
+    [0.8, 0.12, 0],
+    [0.5, 0.78, 0],
+    [0.78, 0.5, 0],
+    [0.25, 0.25, 0],
+  ];
 }

--- a/shared/CenterPileUtils.ts
+++ b/shared/CenterPileUtils.ts
@@ -1,0 +1,50 @@
+import type { BoardState } from "./GameUtils";
+
+const BOARD_CENTER_X = 0.5;
+const BOARD_CENTER_Y = 0.5;
+
+export function getBoardPileDistanceToBoardCenter(
+  board: BoardState,
+  pileIndex: number
+): number {
+  const pileLoc = board.pileLocs[pileIndex];
+  if (!pileLoc) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const dx = pileLoc[0] - BOARD_CENTER_X;
+  const dy = pileLoc[1] - BOARD_CENTER_Y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function compareBoardPilesByCenterDistance(
+  board: BoardState,
+  leftIndex: number,
+  rightIndex: number
+): number {
+  return (
+    getBoardPileDistanceToBoardCenter(board, leftIndex) -
+      getBoardPileDistanceToBoardCenter(board, rightIndex) ||
+    leftIndex - rightIndex
+  );
+}
+
+export function getNearestEmptyCenterPileToBoardCenter(
+  board: BoardState
+): number {
+  let nearestIndex = -1;
+
+  for (let index = 0; index < board.piles.length; index++) {
+    if (board.piles[index].length > 0) {
+      continue;
+    }
+    if (
+      nearestIndex < 0 ||
+      compareBoardPilesByCenterDistance(board, index, nearestIndex) < 0
+    ) {
+      nearestIndex = index;
+    }
+  }
+
+  return nearestIndex;
+}

--- a/shared/ComputerV1.ts
+++ b/shared/ComputerV1.ts
@@ -19,6 +19,7 @@ import {
   getBoardPileDistanceToLocation,
   getPlayerLocation,
 } from "./CardLocations";
+import { getBoardPileDistanceToBoardCenter } from "./CenterPileUtils";
 
 export type AIStrategyLean = "solitaire" | "balanced" | "center";
 
@@ -90,15 +91,24 @@ class AIStrategy {
     cursorPosition: readonly [number, number]
   ): void {
     this.boardState.piles.forEach((pile, index) => {
-      const distance = getBoardPileDistanceToLocation(
+      const cursorDistance = getBoardPileDistanceToLocation(
         this.boardState,
         index,
         cursorPosition
       );
       const topCard = peek(pile);
       if (!topCard) {
+        const aceStartDistance = getBoardPileDistanceToBoardCenter(
+          this.boardState,
+          index
+        );
         for (let suitIndex = 0; suitIndex < 4; suitIndex++) {
-          this.indexCenterPileDestination(suitIndex, 1, index, distance);
+          this.indexCenterPileDestination(
+            suitIndex,
+            1,
+            index,
+            aceStartDistance
+          );
         }
         return;
       }
@@ -111,7 +121,7 @@ class AIStrategy {
         getSuitIndex(topCard.suit),
         nextValue,
         index,
-        distance
+        cursorDistance
       );
     });
   }

--- a/shared/MoveHandler.ts
+++ b/shared/MoveHandler.ts
@@ -16,6 +16,7 @@ import {
   couldMatch,
   peek,
 } from "./CardUtils";
+import { getNearestEmptyCenterPileToBoardCenter } from "./CenterPileUtils";
 
 export type Move =
   | {
@@ -100,6 +101,25 @@ export function resolveMoveForBoard(
   }
 
   const emptyPileIndex = boardState.piles.findIndex((pile) => pile.length === 0);
+  return emptyPileIndex >= 0 ? { ...move, dest: emptyPileIndex } : move;
+}
+
+export function resolveAIMoveForBoard(
+  boardState: BoardState,
+  playerIndex: number,
+  move: Move
+): Move {
+  if (move.type !== "c2c") {
+    return resolveMoveForBoard(boardState, playerIndex, move);
+  }
+
+  const player = boardState.players[playerIndex];
+  const topCard = player ? getSourceCard(boardState, player, move) : null;
+  if (topCard?.value !== 1) {
+    return resolveMoveForBoard(boardState, playerIndex, move);
+  }
+
+  const emptyPileIndex = getNearestEmptyCenterPileToBoardCenter(boardState);
   return emptyPileIndex >= 0 ? { ...move, dest: emptyPileIndex } : move;
 }
 

--- a/shared/RoomLogic.ts
+++ b/shared/RoomLogic.ts
@@ -41,6 +41,7 @@ import {
   getDistance,
   getMovePileLocsDelta,
   isProductiveMove,
+  resolveAIMoveForBoard,
   resolveMoveForBoard,
   type Move,
   type MoveResult,
@@ -171,7 +172,7 @@ export function tickRoom(room: RoomState, now = Date.now()): RoomTickResult {
         aiCooldowns[index] = now + getAIRetargetDelay(room);
         continue;
       }
-      const actionMove = move ? resolveMoveForBoard(board, index, move) : null;
+      const actionMove = move ? resolveAIMoveForBoard(board, index, move) : null;
       const moveResult = move
         ? executeMove(board, index, actionMove ?? move, hand, now)
         : null;


### PR DESCRIPTION
## Summary
- Add shared center-pile ranking helpers based on distance from the board center
- Make basic AI choose central empty piles when starting Aces
- Apply central Ace placement as an AI-only move resolution step in the room tick path

## Verification
- node .\\node_modules\\ts-node\\dist\\bin.js --transpile-only shared\\ActionRankingPolicy.test.ts
- node .\\node_modules\\typescript\\bin\\tsc --noEmit --incremental false