### PR TITLE
Restore mobile audio after app resume

### DIFF
--- a/client/soundEffects.test.ts
+++ b/client/soundEffects.test.ts
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+
+type FakeAudioContextState = "running" | "suspended" | "closed" | "interrupted";
+type StoredListener = EventListenerOrEventListenerObject;
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+const originalDocument = (globalThis as { document?: unknown }).document;
+const originalFetch = (globalThis as { fetch?: unknown }).fetch;
+const originalWavExtension = require.extensions[".wav"];
+
+require.extensions[".wav"] = (module, filename) => {
+  module.exports = filename;
+};
+
+async function main(): Promise<void> {
+  await testGestureListenersStayRegisteredAfterUnlock();
+  await testInterruptedContextDoesNotStartSilentSources();
+  restoreGlobals();
+}
+
+async function testGestureListenersStayRegisteredAfterUnlock(): Promise<void> {
+  const env = installFakeBrowser("suspended");
+  const soundEffects = loadSoundEffectsModule();
+
+  soundEffects.setSoundEffectVolumePercent(100);
+  assert.equal(env.getWindowListenerCount("touchstart"), 1);
+
+  env.nextResumeState = "running";
+  env.dispatchWindowEvent("touchstart");
+  await flushAsyncWork();
+
+  assert.equal(env.contexts[0]?.resumeCalls, 1);
+  assert.equal(env.getWindowListenerCount("touchstart"), 1);
+}
+
+async function testInterruptedContextDoesNotStartSilentSources(): Promise<void> {
+  const env = installFakeBrowser("running");
+  const soundEffects = loadSoundEffectsModule();
+
+  soundEffects.setSoundEffectVolumePercent(100);
+  env.dispatchWindowEvent("touchstart");
+  await flushAsyncWork();
+
+  const context = env.contexts[0];
+  assert.ok(context);
+  context.state = "interrupted";
+  env.nextResumeState = "interrupted";
+
+  soundEffects.playRoomActionSound({
+    type: "move",
+    actionId: "test-action",
+    playerIndex: 0,
+    move: { type: "c2c", source: { type: "pounce" }, dest: 0 },
+    time: Date.now(),
+    revision: 1,
+  });
+  await flushAsyncWork();
+
+  assert.equal(context.resumeCalls, 1);
+  assert.equal(env.sourceStartCount, 0);
+  assert.equal(env.getWindowListenerCount("touchstart"), 1);
+}
+
+function installFakeBrowser(initialAudioState: FakeAudioContextState) {
+  const windowListeners = new Map<string, Set<StoredListener>>();
+  const documentListeners = new Map<string, Set<StoredListener>>();
+  const contexts: FakeAudioContext[] = [];
+  const env = {
+    contexts,
+    nextResumeState: "running" as FakeAudioContextState,
+    sourceStartCount: 0,
+    dispatchWindowEvent(eventName: string) {
+      dispatchEvent(windowListeners, eventName);
+    },
+    getWindowListenerCount(eventName: string) {
+      return windowListeners.get(eventName)?.size ?? 0;
+    },
+  };
+
+  class TestAudioContext extends FakeAudioContext {
+    constructor() {
+      super(initialAudioState, env);
+      contexts.push(this);
+    }
+  }
+
+  const fakeWindow = {
+    AudioContext: TestAudioContext,
+    addEventListener(
+      eventName: string,
+      listener: StoredListener
+    ): void {
+      addListener(windowListeners, eventName, listener);
+    },
+    removeEventListener(
+      eventName: string,
+      listener: StoredListener
+    ): void {
+      removeListener(windowListeners, eventName, listener);
+    },
+    requestIdleCallback(): number {
+      return 1;
+    },
+    setTimeout,
+    fetch: fakeFetch,
+  };
+  const fakeDocument = {
+    visibilityState: "visible",
+    addEventListener(
+      eventName: string,
+      listener: StoredListener
+    ): void {
+      addListener(documentListeners, eventName, listener);
+    },
+    removeEventListener(
+      eventName: string,
+      listener: StoredListener
+    ): void {
+      removeListener(documentListeners, eventName, listener);
+    },
+  };
+
+  (globalThis as { window?: unknown }).window = fakeWindow;
+  (globalThis as { document?: unknown }).document = fakeDocument;
+  (globalThis as { fetch?: unknown }).fetch = fakeFetch;
+
+  return env;
+}
+
+class FakeAudioContext {
+  currentTime = 0;
+  resumeCalls = 0;
+  private readonly listeners = new Map<string, Set<StoredListener>>();
+
+  constructor(
+    public state: FakeAudioContextState,
+    private readonly env: {
+      nextResumeState: FakeAudioContextState;
+      sourceStartCount: number;
+    }
+  ) {}
+
+  addEventListener(eventName: string, listener: StoredListener): void {
+    addListener(this.listeners, eventName, listener);
+  }
+
+  removeEventListener(eventName: string, listener: StoredListener): void {
+    removeListener(this.listeners, eventName, listener);
+  }
+
+  async resume(): Promise<void> {
+    this.resumeCalls += 1;
+    this.state = this.env.nextResumeState;
+    dispatchEvent(this.listeners, "statechange");
+  }
+
+  decodeAudioData(
+    _audioData: ArrayBuffer,
+    successCallback?: DecodeSuccessCallback | null
+  ): Promise<AudioBuffer> {
+    const buffer = {} as AudioBuffer;
+    successCallback?.(buffer);
+    return Promise.resolve(buffer);
+  }
+
+  createBufferSource(): AudioBufferSourceNode {
+    const env = this.env;
+    return {
+      buffer: null,
+      playbackRate: { setValueAtTime() {} },
+      connect() {},
+      disconnect() {},
+      start() {
+        env.sourceStartCount += 1;
+      },
+    } as unknown as AudioBufferSourceNode;
+  }
+
+  createGain(): GainNode {
+    return {
+      gain: { setValueAtTime() {} },
+      connect() {},
+      disconnect() {},
+    } as unknown as GainNode;
+  }
+}
+
+function addListener(
+  listeners: Map<string, Set<StoredListener>>,
+  eventName: string,
+  listener: StoredListener
+): void {
+  const existing = listeners.get(eventName);
+  if (existing) {
+    existing.add(listener);
+    return;
+  }
+
+  listeners.set(eventName, new Set([listener]));
+}
+
+function removeListener(
+  listeners: Map<string, Set<StoredListener>>,
+  eventName: string,
+  listener: StoredListener
+): void {
+  listeners.get(eventName)?.delete(listener);
+}
+
+function dispatchEvent(
+  listeners: Map<string, Set<StoredListener>>,
+  eventName: string
+): void {
+  listeners.get(eventName)?.forEach((listener) => {
+    if (typeof listener === "function") {
+      listener({ type: eventName } as Event);
+      return;
+    }
+
+    listener.handleEvent({ type: eventName } as Event);
+  });
+}
+
+function fakeFetch(): Promise<{
+  ok: true;
+  arrayBuffer: () => Promise<ArrayBuffer>;
+}> {
+  return Promise.resolve({
+    ok: true,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+  });
+}
+
+function loadSoundEffectsModule(): typeof import("./soundEffects") {
+  const modulePath = require.resolve("./soundEffects");
+  delete require.cache[modulePath];
+  return require("./soundEffects") as typeof import("./soundEffects");
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function restoreGlobals(): void {
+  restoreGlobal("window", originalWindow);
+  restoreGlobal("document", originalDocument);
+  restoreGlobal("fetch", originalFetch);
+  restoreRequireExtension(".wav", originalWavExtension);
+}
+
+function restoreGlobal(name: "window" | "document" | "fetch", value: unknown) {
+  if (value === undefined) {
+    delete (globalThis as Record<string, unknown>)[name];
+    return;
+  }
+
+  (globalThis as Record<string, unknown>)[name] = value;
+}
+
+function restoreRequireExtension(
+  extension: string,
+  value: NodeJS.RequireExtensions[string] | undefined
+): void {
+  if (value) {
+    require.extensions[extension] = value;
+    return;
+  }
+
+  delete require.extensions[extension];
+}
+
+void main().catch((error) => {
+  restoreGlobals();
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/client/soundEffects.ts
+++ b/client/soundEffects.ts
@@ -56,13 +56,17 @@ export const DEFAULT_SOUND_EFFECT_VOLUME_PERCENT = 0;
 let audioContext: AudioContext | null = null;
 let soundEffectVolumeMultiplier = DEFAULT_SOUND_EFFECT_VOLUME_PERCENT / 100;
 let didRegisterAudioUnlockListeners = false;
+let didRegisterAudioLifecycleListeners = false;
 
 export function setSoundEffectVolumePercent(volumePercent: number): void {
   soundEffectVolumeMultiplier = clampVolume(volumePercent / 100);
 
   if (soundEffectVolumeMultiplier > 0) {
     registerAudioUnlockListeners();
+    registerAudioLifecycleListeners();
     runWhenIdle(preloadDecodedSoundEffects);
+  } else {
+    removeAudioUnlockListeners();
   }
 }
 
@@ -203,14 +207,11 @@ async function playWebAudioSoundEffect(
     return;
   }
 
-  const resumePromise =
-    context.state === "suspended"
-      ? context.resume().catch(ignoreAudioLoadError)
-      : Promise.resolve();
+  const resumePromise = resumeAudioContext(context);
   const buffer = await loadAudioBuffer(soundEffect);
   await resumePromise;
 
-  if (context.state === "suspended") {
+  if (!isAudioContextRunning(context)) {
     registerAudioUnlockListeners();
     return;
   }
@@ -300,6 +301,12 @@ function getAudioContext(): AudioContext | null {
   }
 
   audioContext = new AudioContextConstructor();
+  if (typeof audioContext.addEventListener === "function") {
+    audioContext.addEventListener(
+      "statechange",
+      handleAudioContextStateChange
+    );
+  }
   return audioContext;
 }
 
@@ -340,6 +347,7 @@ const AUDIO_UNLOCK_EVENTS = [
 
 function unlockAudioPlayback(): void {
   if (soundEffectVolumeMultiplier <= 0) {
+    removeAudioUnlockListeners();
     return;
   }
 
@@ -349,14 +357,13 @@ function unlockAudioPlayback(): void {
     return;
   }
 
-  const resumePromise =
-    context.state === "suspended"
-      ? context.resume().catch(ignoreAudioLoadError)
-      : Promise.resolve();
-  void resumePromise.then(() => {
-    preloadDecodedSoundEffects();
-    if (context.state === "running") {
-      removeAudioUnlockListeners();
+  if (isAudioContextRunning(context)) {
+    return;
+  }
+
+  void resumeAudioContext(context).then(() => {
+    if (isAudioContextRunning(context)) {
+      preloadDecodedSoundEffects();
     }
   });
 }
@@ -370,6 +377,82 @@ function removeAudioUnlockListeners(): void {
   AUDIO_UNLOCK_EVENTS.forEach((eventName) => {
     window.removeEventListener(eventName, unlockAudioPlayback);
   });
+}
+
+function registerAudioLifecycleListeners(): void {
+  if (typeof window === "undefined" || didRegisterAudioLifecycleListeners) {
+    return;
+  }
+
+  didRegisterAudioLifecycleListeners = true;
+  const options = { passive: true };
+  window.addEventListener("focus", handleAudioResumeOpportunity, options);
+  window.addEventListener("pageshow", handleAudioResumeOpportunity, options);
+  if (typeof document !== "undefined") {
+    document.addEventListener(
+      "visibilitychange",
+      handleAudioResumeOpportunity
+    );
+  }
+}
+
+function handleAudioContextStateChange(): void {
+  if (soundEffectVolumeMultiplier <= 0 || !audioContext) {
+    return;
+  }
+
+  if (!isAudioContextRunning(audioContext)) {
+    registerAudioUnlockListeners();
+  }
+}
+
+function handleAudioResumeOpportunity(): void {
+  if (soundEffectVolumeMultiplier <= 0 || isDocumentHidden()) {
+    return;
+  }
+
+  if (!audioContext) {
+    registerAudioUnlockListeners();
+    return;
+  }
+
+  if (isAudioContextRunning(audioContext)) {
+    return;
+  }
+
+  registerAudioUnlockListeners();
+  void resumeAudioContext(audioContext).then(() => {
+    if (audioContext && isAudioContextRunning(audioContext)) {
+      preloadDecodedSoundEffects();
+    }
+  });
+}
+
+function resumeAudioContext(context: AudioContext): Promise<void> {
+  if (!shouldResumeAudioContext(context)) {
+    return Promise.resolve();
+  }
+
+  return context.resume().catch(ignoreAudioLoadError);
+}
+
+function shouldResumeAudioContext(context: AudioContext): boolean {
+  const state = getAudioContextState(context);
+  return state !== "running" && state !== "closed";
+}
+
+function isAudioContextRunning(context: AudioContext): boolean {
+  return getAudioContextState(context) === "running";
+}
+
+function getAudioContextState(context: AudioContext): string {
+  return context.state;
+}
+
+function isDocumentHidden(): boolean {
+  return (
+    typeof document !== "undefined" && document.visibilityState === "hidden"
+  );
 }
 
 function ignoreAudioLoadError(): void {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:action-ranking-policy": "ts-node --transpile-only shared/ActionRankingPolicy.test.ts",
     "test:room-delta": "node ./node_modules/ts-node/dist/bin.js --transpile-only shared/RoomDelta.test.ts",
     "test:socket-state": "node ./node_modules/ts-node/dist/bin.js --transpile-only client/SocketState.test.ts",
+    "test:sound-effects": "node ./node_modules/ts-node/dist/bin.js --transpile-only client/soundEffects.test.ts",
     "test:pounce-rush": "ts-node --transpile-only shared/PounceRush.test.ts",
     "lint": "next lint"
   },


### PR DESCRIPTION
## Summary
- keep audio unlock listeners available while sound effects are enabled
- resume non-running Web Audio contexts on focus/pageshow/visibility/state changes before starting sounds
- add a focused sound effects regression test for resumed/interrupted mobile audio contexts

## Tests
- npm.cmd run test:sound-effects
- npx.cmd tsc --noEmit --incremental false