### PR TITLE
Drop AI Ace field positions when retargeting

### DIFF
--- a/shared/ActionRankingPolicy.test.ts
+++ b/shared/ActionRankingPolicy.test.ts
@@ -134,6 +134,7 @@ assert.notStrictEqual(deckCycleFeatureIndex, -1);
     type: "c2c",
     source: { type: "pounce" },
     dest: 0,
+    position: [0.05, 0.05],
   };
   const genericResolvedMove = resolveMoveForBoard(board, 0, offCenterAceMove);
   assert.strictEqual(
@@ -147,6 +148,11 @@ assert.notStrictEqual(deckCycleFeatureIndex, -1);
     resolvedAIMove.type === "c2c" ? resolvedAIMove.dest : -1,
     2,
     "AI move resolution should retarget Aces to the most central empty pile"
+  );
+  assert.strictEqual(
+    resolvedAIMove.type === "c2c" ? resolvedAIMove.position : undefined,
+    undefined,
+    "AI Ace retargeting should not keep a field-slot position"
   );
 
   board.piles[0] = [card("spades", 1, 1)];

--- a/shared/MoveHandler.ts
+++ b/shared/MoveHandler.ts
@@ -120,7 +120,9 @@ export function resolveAIMoveForBoard(
   }
 
   const emptyPileIndex = getNearestEmptyCenterPileToBoardCenter(boardState);
-  return emptyPileIndex >= 0 ? { ...move, dest: emptyPileIndex } : move;
+  return emptyPileIndex >= 0
+    ? { type: "c2c", source: move.source, dest: emptyPileIndex }
+    : move;
 }
 
 export function getMovePileLocsDelta(


### PR DESCRIPTION
## Summary
- Strip custom field-slot positions when AI Ace moves are retargeted to the central empty pile
- Add a regression assertion covering AI Ace retargeting with a carried field position

## Verification
- node .\\node_modules\\ts-node\\dist\\bin.js --transpile-only shared\\ActionRankingPolicy.test.ts
- node .\\node_modules\\typescript\\bin\\tsc --noEmit --incremental false